### PR TITLE
Invalid accountId triggers server crash of unknown origin

### DIFF
--- a/managers/mcp.js
+++ b/managers/mcp.js
@@ -29,8 +29,11 @@ module.exports = (app) => {
 
 				//creating profile if it doesn't exist
 				try {
-					fs.mkdirSync(`./config/${accountId}/profiles`, { recursive: true });
-					Profile.saveProfile(accountId, profileId, profileData);
+					// Sync [FIX]
+					if (accountId.length >= 32) {
+						fs.mkdirSync(`./config/${accountId}/profiles`, { recursive: true });
+						Profile.saveProfile(accountId, profileId, profileData);
+					}
 				} catch (e) {
 					console.log("Failed creating profile");
 					throw e;

--- a/profile.js
+++ b/profile.js
@@ -185,6 +185,10 @@ module.exports = {
 },
 
     saveProfile(accountId, profileId, data) {
-        fs.writeFileSync(path.join(__dirname, `/config/${accountId}/profiles/profile_${profileId}.json`), JSON.stringify(data, null, 2));
+        if (accountId.length >= 32) {
+            fs.writeFileSync(path.join(__dirname, `/config/${accountId}/profiles/profile_${profileId}.json`), JSON.stringify(data, null, 2));
+        } else {
+            return;
+        }
     }
 };


### PR DESCRIPTION
Invalid/plentiful accountIds in the config cause server crash of unknown origin.

Has been exploited in the wild.