### PR TITLE
Fixed news button so it now says 'join our discord'

### DIFF
--- a/managers/Fortnite-Game.js
+++ b/managers/Fortnite-Game.js
@@ -1401,7 +1401,7 @@ module.exports = (app, port) => {
                         "videoFullscreen": false,
                         "spotlight": false,
                         "websiteURL": "https://discord.gg/DJ6VUmD",
-                        "websiteButtonTex" : "Join our discord"
+                        "websiteButtonText" : "Join our discord"
                     }
                 ],
                 },
@@ -1436,7 +1436,7 @@ module.exports = (app, port) => {
                         "videoFullscreen": false,
                         "spotlight": false,
                         "websiteURL": "https://discord.gg/DJ6VUmD",
-                        "websiteButtonTex" : "Join our discord"
+                        "websiteButtonText" : "Join our discord"
                     }
                 ],
                 },


### PR DESCRIPTION
Fixed the news button so it now says 'join our discord' instead of 'open website' like it was meant to do in the first place. 