### PR TITLE
Fix link to launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ _In acquiescence to Epic Games Inc. - Please note that access to all cosmetics f
 - Extract the source code.
 - Open `install.bat` and wait for it to install. (only required on the first run!)	
 - Open `run.bat`, it should say `[Neonite]: v2.7.3 is listening on port 5595!` (DON'T CLOSE THIS WHILE USING NEONITE!)	
-- Download the **[launcher](https://github.com/NeoniteDev/NeoniteV2/blob/main/public/launcher.zip?raw=true)**.	
+- Download the **[launcher](https://github.com/NeoniteDev/NeoniteV2/blob/main/public/Launcher.zip?raw=true)**.	
 - Extract the launcher and open `Silver.exe`.
 - Type in your username, make sure to put "@." at the end or it won't let you login. (don't use any special characters or spaces.)
 - Type a random password (doesn't matter what you put, so you can login)	


### PR DESCRIPTION
users were unable to download the old launcher(since the link has changed)
Changed from "https://github.com/NeoniteDev/NeoniteV2/blob/main/public/launcher.zip?raw=true"
to "https://github.com/NeoniteDev/NeoniteV2/blob/main/public/Launcher.zip?raw=true"