### PR TITLE
Add support for (un-)archiving locker items

### DIFF
--- a/managers/mcp.js
+++ b/managers/mcp.js
@@ -499,6 +499,17 @@ module.exports = (app) => {
 				break;
 			}
 
+			case "SetItemArchivedStatusBatch": {
+				checkValidProfileID("campaign", "athena");
+
+				req.body.itemIds.forEach(itemId => {
+					if (typeof itemId === "string" && typeof req.body.archived === "boolean") {
+						Profile.changeItemAttribute(profileData, itemId, "archived", req.body.archived, profileChanges);
+					}
+				});
+				break;
+			}
+
 			case "SetMtxPlatform": {
 				checkValidProfileID("common_core");
 


### PR DESCRIPTION
This PR adds support for (un-)archiving of locker items. Right now the game just shows an error message due to a missing / incorrect response for the `SetItemArchivedStatusBatch` command request.